### PR TITLE
DMP-1845 Add Request Matching for ARM Disposition: /api/v3/UpdateMetadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ dependencies {
 
   implementation group: 'io.rest-assured', name: 'rest-assured'
   implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '3.0.1')
+  implementation(group: 'org.wiremock', name: 'wiremock-standalone', version: '3.3.1')
 
   testImplementation(platform('org.junit:junit-bom:5.10.1'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
 
   implementation group: 'io.rest-assured', name: 'rest-assured'
-  implementation (group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '2.35.1')
+  implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '3.0.1')
 
   testImplementation(platform('org.junit:junit-bom:5.10.1'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
@@ -228,5 +228,5 @@ rootProject.tasks.named("processSmokeTestResources") {
 }
 
 wrapper {
-    distributionType = Wrapper.DistributionType.ALL
+  distributionType = Wrapper.DistributionType.ALL
 }

--- a/src/main/java/uk/gov/hmcts/darts/stub/services/config/WireMockServerConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/stub/services/config/WireMockServerConfig.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.stub.services.config;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +34,8 @@ public class WireMockServerConfig {
 
         LOG.info("Stubs registered with wiremock");
         wireMockServer.getStubMappings().forEach(w -> LOG.info("\nRequest : {}, \nResponse: {}", w.getRequest(),
-                w.getResponse()));
+                                                               w.getResponse()
+        ));
 
         return wireMockServer;
     }
@@ -43,23 +43,22 @@ public class WireMockServerConfig {
     private WireMockConfiguration getWireMockConfig() {
         var mappingDirectory = new File(mappingsPath + MAPPINGS_DIRECTORY_NAME);
         LOG.info("Mappings directory path: {}", mappingDirectory.getAbsolutePath());
-        var responseTemplating = new ResponseTemplateTransformer(true);
 
         if (mappingDirectory.isDirectory()) {
             return options()
-                .stubCorsEnabled(false)
-                .dynamicHttpsPort()
-                .dynamicPort()
-                .usingFilesUnderDirectory(mappingsPath)
-                .extensions(responseTemplating);
+                    .stubCorsEnabled(false)
+                    .dynamicHttpsPort()
+                    .dynamicPort()
+                    .usingFilesUnderDirectory(mappingsPath)
+                    .globalTemplating(true);
         } else {
             LOG.info("using classpath resources to resolve mappings");
             return options()
-                .stubCorsEnabled(false)
-                .dynamicHttpsPort()
-                .dynamicPort()
-                .usingFilesUnderClasspath(mappingsPath)
-                .extensions(responseTemplating);
+                    .stubCorsEnabled(false)
+                    .dynamicHttpsPort()
+                    .dynamicPort()
+                    .usingFilesUnderClasspath(mappingsPath)
+                    .globalTemplating(true);
         }
     }
 }

--- a/wiremock/mappings/arm/v3_UpdateMetadata.json
+++ b/wiremock/mappings/arm/v3_UpdateMetadata.json
@@ -1,7 +1,19 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/api/v3/UpdateMetadata"
+    "urlPath": "/api/v3/UpdateMetadata",
+    "bodyPatterns": [
+      {
+        "matchesJsonSchema": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"UseGuidsForFields\",\n    \"manifest\",\n    \"itemId\"\n  ],\n  \"properties\": {\n    \"UseGuidsForFields\": {\n      \"type\": \"boolean\"\n    },\n    \"manifest\": {\n      \"type\": \"object\",\n      \"required\": [\n        \"event_date\"\n      ],\n      \"properties\": {\n        \"event_date\": {\n          \"type\": \"string\"\n        }\n      }\n    },\n    \"itemId\": {\n      \"type\": \"string\"\n    }\n  }\n}",
+        "schemaVersion": "V202012"
+      },
+      {
+        "matchesJsonPath": {
+          "expression": "$.UseGuidsForFields",
+          "contains": "false"
+        }
+      }
+    ]
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-1845](https://tools.hmcts.net/jira/browse/DMP-1845)

### Change description ###

Add wiremock-jre8 Latest version: 3.0.1 that supports matchesJsonSchema and matchesJsonPath "UseGuidsForFields":false

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
