### PR TITLE
DMP-2151: Add ARM token stub

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/stub/services/controllers/WiremockRequestForwardingController.java
+++ b/src/main/java/uk/gov/hmcts/darts/stub/services/controllers/WiremockRequestForwardingController.java
@@ -36,7 +36,7 @@ public class WiremockRequestForwardingController {
 
     private static final String CATCH_ALL_PATH = "**";
     private static final Set<String> EXCLUDED_HEADERS = Set.of(
-            "host", "connection", "accept-encoding", "content-length"
+            "host", "connection", "accept-encoding", "content-length", "transfer-encoding"
     );
 
     @Value("${wiremock.server.host}")
@@ -53,7 +53,8 @@ public class WiremockRequestForwardingController {
     @GetMapping(CATCH_ALL_PATH)
     public ResponseEntity<Resource> forwardGetRequests(HttpServletRequest request)
             throws IOException, InterruptedException {
-        return forwardRequest(request, BodyPublishers.noBody(), HttpMethod.GET);
+        var requestBody = IOUtils.toString(request.getInputStream());
+        return forwardRequest(request, BodyPublishers.ofString(requestBody), HttpMethod.GET);
     }
 
     @PostMapping(CATCH_ALL_PATH)

--- a/wiremock/mappings/arm/v1_token.json
+++ b/wiremock/mappings/arm/v1_token.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/v1/token",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "text/plain"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "access_token": "some-token",
+      "token_type": "Bearer",
+      "expires_in": "3600"
+    }
+  }
+}


### PR DESCRIPTION
# [DMP-2151](https://tools.hmcts.net/jira/browse/DMP-2151)

Add a stub for `GET /api/v1/token`. Intent is for this to be used to facilitate basic happy path for `local`, `dev` and `staging`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
