### PR TITLE
 DMP-1911 changed downloadBlob content type to octet-stream to suppor…

### DIFF
--- a/wiremock/mappings/arm/v1_DownloadBlob.json
+++ b/wiremock/mappings/arm/v1_DownloadBlob.json
@@ -7,7 +7,7 @@
     "status": 200,
     "bodyFileName": "download_blob_test.mp2",
     "headers": {
-      "Content-Type": "audio/mpeg"
+      "Content-Type": "application/octet-stream"
     }
   }
 }


### PR DESCRIPTION
…t files other than audio

### Change description ###
Since ARM will likely allow storing and downloading files other than audio, I've changed the content-type from `audio/mpeg` to a more generic `application/octet-stream`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
