### PR TITLE
DMP-3844 - ARM RPO - Stub for new ARM endpoint - removeProduction

### DIFF
--- a/wiremock/mappings/arm/v1_removeProduction.json
+++ b/wiremock/mappings/arm/v1_removeProduction.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/removeProduction",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{ \"productionId\":\"1b6a29d9-a72e-420b-8d69-b8acbeed806a\", \"deleteSearch\":true }"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "isValid": false,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3844)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=180)


### Change description ###
# Summary of Git Diff

This diff introduces a new JSON mapping file for WireMock, specifically for handling the `removeProduction` API endpoint. The mapping defines a POST request with specific headers and body patterns and specifies the expected JSON response.

## Highlights

- **New File**: `v1_removeProduction.json` added to the `wiremock/mappings/arm` directory.
- **Request Details**:
  - Method: POST
  - URL Path: `/api/v1/removeProduction`
  - Content-Type: `application/json`
  - Body Pattern: Matches a JSON object containing `productionId` and `deleteSearch` attributes.
- **Response Details**:
  - Status Code: 200
  - Content-Type: `application/json`
  - JSON Response Body:
    - `isValid`: false
    - `status`: 200
    - `demoMode`: false
    - `isError`: false
    - `responseStatus`: 0
    - `responseStatusMessages`: null
    - `exception`: null
    - `message`: null

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
