### PR TITLE
DMP-3527: ARM RPO - Stub for new ARM endpoint - getRecordManagementMatter

### DIFF
--- a/wiremock/mappings/arm/v1_getRecordManagementMatter.json
+++ b/wiremock/mappings/arm/v1_getRecordManagementMatter.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/getRecordManagementMatter"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "recordManagementMatter": {
+        "matterCategory": 3,
+        "matterID": "cb70c7fa-8972-4400-af1d-ff5dd76d2104",
+        "name": "Records Management",
+        "isQuickSearch": false,
+        "isUsedForRM": true,
+        "description": "Records Management",
+        "createdDate": "2022-12-14T08:50:55.75+00:00",
+        "type": 1,
+        "status": 0,
+        "userID": null,
+        "backgroundJobID": null,
+        "isClosed": false
+      },
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3527)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=181)


### Change description ###
# Summary of Git Diff

A new JSON configuration file has been added to the WireMock mappings for handling POST requests to the `/api/v1/getRecordManagementMatter` endpoint. This file defines the request and the corresponding response structure, including a sample JSON body.

## Highlights

- **New File Created**: `v1_getRecordManagementMatter.json`
- **Request Method**: POST
- **Request URL Path**: `/api/v1/getRecordManagementMatter`
- **Request Header**: 
  - `Content-Type` must contain `application/json`
- **Response Status**: 200 (OK)
- **Response Header**: 
  - `Content-Type`: `application/json`
- **Response Body**:
  - Contains details of a record management matter, including:
    - `matterCategory`: 3
    - `matterID`: "cb70c7fa-8972-4400-af1d-ff5dd76d2104"
    - `name`: "Records Management"
    - `isUsedForRM`: true
    - `description`: "Records Management"
    - `createdDate`: "2022-12-14T08:50:55.75+00:00"
    - `status`: 0
    - Additional fields for job and user IDs, with values indicating they are not set.
- **Error Handling**: 
  - `isError`: false 
  - `message`: null

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
