### PR TITLE
DMP-3795: ARM RPO - Stub for new ARM endpoint - getIndexesByMatterId

### DIFF
--- a/wiremock/mappings/arm/v1_getIndexesByMatterId.json
+++ b/wiremock/mappings/arm/v1_getIndexesByMatterId.json
@@ -1,0 +1,130 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/getIndexesByMatterId",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{ \"matterId\":\"cb70c7fa-8972-4400-af1d-ff5dd76d2104\" }"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "indexes": [
+        {
+          "index": {
+            "indexID": "c19454c6-c378-43c1-ae59-d0d013e30915",
+            "isGroup": false,
+            "name": "rm5",
+            "displayName": "rm5",
+            "userIndexID": "2f4d6512-64b5-4478-940d-bd29e115591c",
+            "userID": "8b2a9527-e8e2-4430-8e51-b2af4227ff10",
+            "azureSearchAccountID": "dac6878a-6269-48de-981d-3f2f43dfddd2",
+            "indexStatusID": 4,
+            "notified": false,
+            "startDate": null,
+            "endDate": null,
+            "discoveryStartDate": "2023-11-16T13:53:03.94151+00:00",
+            "discoveryEndDate": "2023-11-16T14:36:19.5597796+00:00",
+            "buildStartDate": "2023-11-16T14:37:43.4140026+00:00",
+            "buildEndDate": "2023-11-16T16:22:19.4438814+00:00",
+            "resumeStartDate": "2024-07-25T10:56:39.5283925+00:00",
+            "resumeEndDate": null,
+            "stoppingStartDate": "2024-07-25T09:21:05.1366667+00:00",
+            "stoppingEndDate": null,
+            "createdDate": "2023-11-16T13:52:49.614141+00:00",
+            "totalTime": 8883.4780311,
+            "blobCount": 768987,
+            "blobsProcessed": 768987,
+            "indexDiscoveryItemsCount": 1,
+            "indexDiscoveryItemsProcessed": 1,
+            "exceptionsCount": null,
+            "indexBlobExceptionsCount": 0,
+            "indexDiscoveryItemExceptionsCount": null,
+            "indexBatchJobPartitionsCount": 277,
+            "indexExceptionBatchPartitionsCount": null,
+            "indexUpdateBatchPartitionsCount": 299,
+            "indexUpdateExceptionBatchPartitionsCount": null,
+            "indexBatchLastJobPartitionsCount": null,
+            "indexBlobPartitionsCount": 7651,
+            "indexBlobJobExceptionPartitionsCount": null,
+            "indexBlobLastJobExceptionPartitionsCount": null,
+            "indexDiscoveryItemPartitionsCount": 1,
+            "indexDiscoveryItemExceptionPartitionsCount": null,
+            "indexJobExceptionPartitionsCount": null,
+            "indexLastJobExceptionPartitionsCount": null,
+            "tablePartitionSize": 100,
+            "updateDate": "2023-11-16T13:52:49.614141+00:00",
+            "lastJobID": 0,
+            "jobID": 1,
+            "indexBlobLastJobID": null,
+            "indexBlobJobID": 0,
+            "isContinous": true,
+            "isPrimary": true,
+            "isUsedForRM": true,
+            "continousIndexBlobPartitionsCount": 7935,
+            "requestSizeLimit": 100,
+            "skipContentOverLimit": true,
+            "skipContentIfParserError": true,
+            "fileSizeLimitToTikaParser": 52428800,
+            "sortByResultField": false,
+            "blobContainer": "cloud360",
+            "continuousIndexBatchSize": 16,
+            "continousTablePartitionSize": 100,
+            "isDeleted": false,
+            "mainQueueProcessPriority": 0,
+            "secondaryQueueProcessPriority": 1,
+            "buildBatchesInQueue": 1350,
+            "buildBatchesProcessed": 1350,
+            "buildContinuationToken": "0000000000000000276-0000000000000000000",
+            "buildExceptionContinuationToken": null,
+            "updateContinuationToken": "0000000000000000298-0000000000000000000",
+            "updateExceptionContinuationToken": null,
+            "countOnly": false,
+            "errorCodes": null,
+            "esIndexRolloverSize": null,
+            "esIndexRolloverSizePerShard": 40,
+            "esIndexNoReplicas": 1,
+            "esIndexNoShards": 6,
+            "isDiscoveryCancelled": false,
+            "indexContinuousLastSavedBlobExceptionPartitionsCount": null,
+            "continuousExceptionsInProgress": 0,
+            "preparingContinuousErrorBatches": false,
+            "schemaUpdated": false,
+            "discoveryItemsLock": false,
+            "blobExceptionsStreamUpdateNeeded": false,
+            "streamIDsToProcess": null,
+            "indexUpdateBlobPartitionsCount": 315,
+            "indexUpdateExceptionPartitionsCount": 176,
+            "indexUpdateExceptionsCount": 822,
+            "updateBlobCount": 3918,
+            "updateBlobsProcessed": 3918,
+            "indexLastSavedUpdateExceptionPartitionsCount": null,
+            "updateExceptionsInProgress": 0,
+            "preparingUpdateErrorBatches": false,
+            "poisonHandlingFailed": false
+          },
+          "isMultiStream": false,
+          "children": []
+        }
+      ],
+      "itemsCount": 1,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3795)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=182)


### Change description ###
# Summary of Git Diff

A new JSON file has been added to the `wiremock/mappings/arm/` directory. This file defines a mock API response for the endpoint `/api/v1/getIndexesByMatterId`, detailing the expected request format and the corresponding response structure.

## Highlights

- **New File**: `v1_getIndexesByMatterId.json` created.
- **Request Method**: POST
  - **URL Path**: `/api/v1/getIndexesByMatterId`
  - **Headers**: Requires `Content-Type: application/json`
  - **Body Pattern**: Expects JSON containing a `matterId`.

- **Response Structure**:
  - **Status Code**: 200
  - **Response Content-Type**: `application/json`
  - **Response Body**:
    - Contains an `indexes` array with detailed index information, including:
      - `indexID`, `name`, `userIndexID`, `userID`, and various timestamps.
      - Fields for status, counts, and partition sizes.
      - Flags for continuous processing and error handling.
  - **Items Count**: 1
  - **Status Indicators**: Includes `isError`, `demoMode`, and `responseStatus`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
