### PR TITLE
DMP-3797: ARM RPO - Stub for new ARM endpoint - getProfileEntitlements

### DIFF
--- a/wiremock/mappings/arm/v1_getProfileEntitlements.json
+++ b/wiremock/mappings/arm/v1_getProfileEntitlements.json
@@ -1,0 +1,38 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/getProfileEntitlements"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "entitlements": [
+        {
+          "entitlementID": "96293900-5082-4051-bbad-c961fb22091d",
+          "name": "SRV-DARTS-RW-E",
+          "description": "SRV-DARTS-RW-E",
+          "profileId": "f2a07572-e13e-4939-9d5e-252a372f5115",
+          "isDeleted": false,
+          "profileName": "SRV-DARTS-RW-P",
+          "profileDescription": "Minimum permissions required for UpdateMetadata and DownloadBlob."
+        }
+      ],
+      "itemsCount": 1,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3797)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=184)


### Change description ###
# Summary of Git Diff

This diff introduces a new JSON mapping file for WireMock, defining a mock response for the API endpoint `/api/v1/getProfileEntitlements`. It specifies the request method, headers, and the structure of the response body, including a sample entitlement.

## Highlights

- **New File Created**: `v1_getProfileEntitlements.json`
- **Request Details**:
  - **Method**: POST
  - **Content-Type**: Must contain "application/json"
  - **URL Path**: `/api/v1/getProfileEntitlements`
- **Response Configuration**:
  - **Status**: 200 OK
  - **Response Headers**: Content-Type set to "application/json"
  - **Response Body**:
    - **Entitlements**: Contains one entitlement object with details such as `entitlementID`, `name`, `description`, and associated `profileId`
    - Additional fields include `itemsCount`, `status`, `demoMode`, `isError`, `responseStatus`, and `message` which provide context for the response status and error handling.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
