### PR TITLE
DMP-3799: ARM RPO - Stub for new ARM endpoint - addAsyncSearch

### DIFF
--- a/wiremock/mappings/arm/v1_addAsyncSearch.json
+++ b/wiremock/mappings/arm/v1_addAsyncSearch.json
@@ -19,70 +19,14 @@
       "Content-Type": "application/json"
     },
     "jsonBody": {
-      "queryTree": {
-        "operator": 1,
-        "children": [
-          {
-            "field": {
-              "dataScopeEntitlementNotApplied": true,
-              "removable": false,
-              "draggable": false,
-              "fixedField": true,
-              "history": false,
-              "error": false,
-              "name": "record_class",
-              "valueType": 32,
-              "value": [
-                "DARTS"
-              ]
-            }
-          },
-          {
-            "field": {
-              "dataScopeEntitlementNotApplied": false,
-              "removable": true,
-              "draggable": true,
-              "fixedField": false,
-              "history": false,
-              "error": false,
-              "valueType": 7,
-              "name": "ingestionDate",
-              "value": [
-                "2024-08-12T23:00:00.000Z",
-                "2024-08-13T23:00:00.000Z"
-              ]
-            }
-          }
-        ]
-      },
-      "queryTreeWithin": {
-        "operator": 1,
-        "children": [
-          {
-            "field": {
-              "dataScopeEntitlementNotApplied": false,
-              "removable": true,
-              "draggable": true,
-              "fixedField": false,
-              "history": false,
-              "error": false,
-              "valueType": -1,
-              "name": "",
-              "value": []
-            }
-          }
-        ]
-      },
-      "queryFields": {},
-      "clientTimezone": "Europe/London",
-      "timezone": "Europe/London",
-      "matterId": "cb70c7fa-8972-4400-af1d-ff5dd76d2104",
-      "entitlementId": "96293900-5082-4051-bbad-c961fb22091d",
-      "indexId": "c19454c6-c378-43c1-ae59-d0d013e30915",
-      "sortingField": "90ee0e13-8639-4c4a-b542-66b6c8911549",
-      "sortingType": 1,
-      "name": "DARTS_RPO_2024-08-13",
-      "searchName": "DARTS_RPO_2024-08-13"
+      "searchId": "8271f101-8c14-4c41-8865-edc5d8baed99",
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
     }
   }
 }

--- a/wiremock/mappings/arm/v1_addAsyncSearch.json
+++ b/wiremock/mappings/arm/v1_addAsyncSearch.json
@@ -1,0 +1,88 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/addAsyncSearch",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"queryTree\":{\"operator\":1,\"children\":[{\"field\":{\"dataScopeEntitlementNotApplied\":true,\"removable\":false,\"draggable\":false,\"fixedField\":true,\"history\":false,\"error\":false,\"name\":\"record_class\",\"valueType\":32,\"value\":[\"DARTS\"]}},{\"field\":{\"dataScopeEntitlementNotApplied\":false,\"removable\":true,\"draggable\":true,\"fixedField\":false,\"history\":false,\"error\":false,\"valueType\":7,\"name\":\"ingestionDate\",\"value\":[\"2024-08-12T23:00:00.000Z\",\"2024-08-13T23:00:00.000Z\"]}}]},\"queryTreeWithin\":{\"operator\":1,\"children\":[{\"field\":{\"dataScopeEntitlementNotApplied\":false,\"removable\":true,\"draggable\":true,\"fixedField\":false,\"history\":false,\"error\":false,\"valueType\":-1,\"name\":\"\",\"value\":[]}}]},\"queryFields\":{},\"clientTimezone\":\"Europe/London\",\"timezone\":\"Europe/London\",\"matterId\":\"cb70c7fa-8972-4400-af1d-ff5dd76d2104\",\"entitlementId\":\"96293900-5082-4051-bbad-c961fb22091d\",\"indexId\":\"c19454c6-c378-43c1-ae59-d0d013e30915\",\"sortingField\":\"90ee0e13-8639-4c4a-b542-66b6c8911549\",\"sortingType\":1,\"name\":\"DARTS_RPO_2024-08-13\",\"searchName\":\"DARTS_RPO_2024-08-13\"}"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "queryTree": {
+        "operator": 1,
+        "children": [
+          {
+            "field": {
+              "dataScopeEntitlementNotApplied": true,
+              "removable": false,
+              "draggable": false,
+              "fixedField": true,
+              "history": false,
+              "error": false,
+              "name": "record_class",
+              "valueType": 32,
+              "value": [
+                "DARTS"
+              ]
+            }
+          },
+          {
+            "field": {
+              "dataScopeEntitlementNotApplied": false,
+              "removable": true,
+              "draggable": true,
+              "fixedField": false,
+              "history": false,
+              "error": false,
+              "valueType": 7,
+              "name": "ingestionDate",
+              "value": [
+                "2024-08-12T23:00:00.000Z",
+                "2024-08-13T23:00:00.000Z"
+              ]
+            }
+          }
+        ]
+      },
+      "queryTreeWithin": {
+        "operator": 1,
+        "children": [
+          {
+            "field": {
+              "dataScopeEntitlementNotApplied": false,
+              "removable": true,
+              "draggable": true,
+              "fixedField": false,
+              "history": false,
+              "error": false,
+              "valueType": -1,
+              "name": "",
+              "value": []
+            }
+          }
+        ]
+      },
+      "queryFields": {},
+      "clientTimezone": "Europe/London",
+      "timezone": "Europe/London",
+      "matterId": "cb70c7fa-8972-4400-af1d-ff5dd76d2104",
+      "entitlementId": "96293900-5082-4051-bbad-c961fb22091d",
+      "indexId": "c19454c6-c378-43c1-ae59-d0d013e30915",
+      "sortingField": "90ee0e13-8639-4c4a-b542-66b6c8911549",
+      "sortingType": 1,
+      "name": "DARTS_RPO_2024-08-13",
+      "searchName": "DARTS_RPO_2024-08-13"
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3799)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=186)


### Change description ###
# Summary of Git Diff

This Git diff adds a new JSON mapping file for the `/api/v1/addAsyncSearch` endpoint to the WireMock configuration. The file defines a POST request with specific header and body patterns, as well as a structured JSON response.

## Highlights

- **New Mapping File**: A new file `v1_addAsyncSearch.json` is created under `wiremock/mappings/arm/`.
- **Request Details**:
  - **Method**: POST
  - **URL Path**: `/api/v1/addAsyncSearch`
  - **Headers**: Requires `Content-Type` to contain `application/json`
  - **Body Patterns**: Includes a complex JSON body with fields such as `queryTree`, `clientTimezone`, `timezone`, `matterId`, `entitlementId`, `indexId`, and `sortingField`.
  
- **Response Details**:
  - **Status Code**: 200
  - **Response Headers**: `Content-Type` set to `application/json`
  - **JSON Body**: Mirrors the structure of the request body, including `queryTree`, `clientTimezone`, `matterId`, etc. 

This setup enables testing and mocking of the `addAsyncSearch` functionality within the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
