### PR TITLE
DMP-3800: ARM RPO - Stub for new ARM endpoint - SaveBackgroundSearch

### DIFF
--- a/wiremock/mappings/arm/v1_SaveBackgroundSearch.json
+++ b/wiremock/mappings/arm/v1_SaveBackgroundSearch.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/SaveBackgroundSearch",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"name\":\"DARTS_RPO_2024-08-13\",\"searchId\":\"8271f101-8c14-4c41-8865-edc5d8baed99\"}"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "isValid": false,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3800)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=187)


### Change description ###
# Summary of Git Diff

A new JSON mapping file for WireMock was created to define the behavior of a POST request to the `/api/v1/SaveBackgroundSearch` endpoint. The mapping includes request patterns and a response structure.

## Highlights

- **File Created**: `v1_SaveBackgroundSearch.json`
- **Request Method**: POST
- **Request URL Path**: `/api/v1/SaveBackgroundSearch`
- **Request Headers**: 
  - `Content-Type`: must contain `application/json`
- **Request Body Pattern**: Matches specific JSON structure with `name` and `searchId`.
- **Response Status**: 200
- **Response Content-Type**: `application/json`
- **Response JSON Body**: 
  - `isValid`: false
  - `status`: 200
  - `demoMode`: false
  - `isError`: false
  - `responseStatus`: 0
  - Other fields include `responseStatusMessages`, `exception`, and `message` set to null.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
