### PR TITLE
DMP-3801: ARM RPO - Stub for new ARM endpoint - createExportBasedOnSearchResultsTable

### DIFF
--- a/wiremock/mappings/arm/v1_createExportBasedOnSearchResultsTable.json
+++ b/wiremock/mappings/arm/v1_createExportBasedOnSearchResultsTable.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/createExportBasedOnSearchResultsTable",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"core\":null,\"formFields\":null,\"searchId\":\"8271f101-8c14-4c41-8865-edc5d8baed99\",\"searchitemsCount\":\"5\",\"headerColumns\":[{\"masterIndexField\":\"200b9c27-b497-4977-82e7-1586b32a5871\",\"displayName\":\"Record Class\",\"propertyName\":\"record_class\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"90ee0e13-8639-4c4a-b542-66b6c8911549\",\"displayName\":\"Archived Date\",\"propertyName\":\"ingestionDate\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"a9b8daf2-d9ff-4815-b65a-f6ae2763b92c\",\"displayName\":\"Client Identifier\",\"propertyName\":\"client_identifier\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"109b6bf1-57a0-48ec-b22e-c7248dc74f91\",\"displayName\":\"Contributor\",\"propertyName\":\"contributor\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"893048bf-1e7c-4811-9abf-00cd77a715cf\",\"displayName\":\"Record Date\",\"propertyName\":\"recordDate\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"fdd0fcbb-da46-4af1-a627-ac255c12bb23\",\"displayName\":\"ObjectId\",\"propertyName\":\"bf_012\",\"propertyType\":\"number\",\"isMasked\":false},{\"masterIndexField\":\"1332b6b2-d4b1-4a9a-b13d-f5a08d9cc803\",\"displayName\":\"ParentId\",\"propertyName\":\"bf_013\",\"propertyType\":\"number\",\"isMasked\":false},{\"masterIndexField\":\"0eb3adc8-f220-4074-9ad4-64c43313b5c6\",\"displayName\":\"Channel\",\"propertyName\":\"bf_014\",\"propertyType\":\"number\",\"isMasked\":false},{\"masterIndexField\":\"9af92904-442c-44c1-916c-c1ee6d019140\",\"displayName\":\"MaxChannels\",\"propertyName\":\"bf_015\",\"propertyType\":\"number\",\"isMasked\":false},{\"masterIndexField\":\"03d413d8-126e-4330-ba76-ff09405c2856\",\"displayName\":\"ObjectType\",\"propertyName\":\"bf_001\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"2fdfffce-0390-44b0-9b3f-038b790f26ad\",\"displayName\":\"CaseNumbers\",\"propertyName\":\"bf_002\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"6afc68a3-ea09-478c-ad28-a57b846c4d57\",\"displayName\":\"FileType\",\"propertyName\":\"bf_003\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"5aa6b522-bcee-44d3-95d2-5497a636f387\",\"displayName\":\"Checksum\",\"propertyName\":\"bf_005\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"b885df16-7ce4-404c-a0c6-036d071d6a2f\",\"displayName\":\"TranscriptRequest\",\"propertyName\":\"bf_006\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"7cbc7937-87e6-4f8e-bc7b-de552ca8ed1e\",\"displayName\":\"TranscriptType\",\"propertyName\":\"bf_007\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"ad3b574b-f0c7-492e-8a47-c9645b558c09\",\"displayName\":\"TranscriptUrgency\",\"propertyName\":\"bf_008\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"1337a236-c482-4a7d-baa3-4875cb484767\",\"displayName\":\"Comments\",\"propertyName\":\"bf_009\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"ea88ea00-fb7c-41a3-b0c8-adf2bfb8df18\",\"displayName\":\"UploadedBy\",\"propertyName\":\"bf_016\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"5865d506-87d9-4733-8efc-026d636793d4\",\"displayName\":\"HearingDate\",\"propertyName\":\"bf_004\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"519d88cb-dad2-4c6a-ac3a-b41bc3519c68\",\"displayName\":\"CreatedDateTime\",\"propertyName\":\"bf_010\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"0c5b03b8-86f0-45df-a6ab-17085131b54c\",\"displayName\":\"StartDateTime\",\"propertyName\":\"bf_011\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"9fb67f04-5fac-4d41-97ef-ac92267ff0e7\",\"displayName\":\"EndDateTime\",\"propertyName\":\"bf_017\",\"propertyType\":\"date\",\"isMasked\":false},{\"masterIndexField\":\"11dc6223-fd52-4714-950b-d74d721f1dae\",\"displayName\":\"Courthouse\",\"propertyName\":\"bf_019\",\"propertyType\":\"string\",\"isMasked\":false},{\"masterIndexField\":\"ae888318-1500-44f4-92b9-f09824e6ae1f\",\"displayName\":\"Courtroom\",\"propertyName\":\"bf_020\",\"propertyType\":\"string\",\"isMasked\":false}],\"productionName\":\"DARTS_RPO_2024-08-13_CSV\",\"storageAccountId\":\"aeb01bc8-9292-47a7-88a3-8fc89ebc3e10\"}"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "isValid": false,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3801)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=188)


### Change description ###
# Summary of Git Diff

A new JSON mapping file for WireMock has been added. This file defines a POST API endpoint for creating export based on search results, including request and response specifications.

## Highlights

- **New File Created**: `v1_createExportBasedOnSearchResultsTable.json`
- **Request Method**: `POST`
- **Request URL Path**: `/api/v1/createExportBasedOnSearchResultsTable`
- **Request Body**: 
  - Contains a JSON object with several fields including `searchId`, `searchitemsCount`, and an array of `headerColumns` representing various attributes.
- **Response Specification**:
  - Status code: `200`
  - Response body indicates whether the request is valid with fields like `isValid`, `isError`, and `responseStatus`. 
- **Content-Type for Request and Response**: `application/json`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
