### PR TITLE
DMP-3803: ARM RPO - Stub for new ARM endpoint - getProductionOutputFiles

### DIFF
--- a/wiremock/mappings/arm/v1_getProductionOutputFiles.json
+++ b/wiremock/mappings/arm/v1_getProductionOutputFiles.json
@@ -1,0 +1,119 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/getProductionOutputFiles",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{ \"productionId\":\"1b6a29d9-a72e-420b-8d69-b8acbeed806a\" }"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "production": {
+        "edrmFile": false,
+        "csvSummary": true,
+        "binary": false,
+        "manifest": false,
+        "productionID": "1b6a29d9-a72e-420b-8d69-b8acbeed806a",
+        "matterID": "cb70c7fa-8972-4400-af1d-ff5dd76d2104",
+        "name": "DARTS_RPO_2024-08-13_CSV",
+        "description": "search grid results",
+        "status": 4,
+        "errorCode": 0,
+        "errorDescr": null,
+        "bates": false,
+        "exportType": 32,
+        "nativeMsgToPst": false,
+        "flattenFolderHierarchy": false,
+        "nativeMaxContainerSize": 1000,
+        "nativeMaxItemsPerContainer": 500000,
+        "nativeIncludeJournalReport": false,
+        "pdfSearchablePDF": false,
+        "pdfConsolidateItems": false,
+        "pdfPageBreak": false,
+        "pdfItemsPerExportFile": 0,
+        "lastUpdateTime": "2024-08-13T16:50:21.1505806+00:00",
+        "startProductionTime": "2024-08-13T16:50:15.4091127+00:00",
+        "endProductionTime": "2024-08-13T16:50:21.1592576+00:00",
+        "createdDate": "2024-08-13T16:50:12.6428988+00:00",
+        "custodianID": 7812,
+        "itemsCount": 5,
+        "estimateCount": 5,
+        "processedItemsCount": 5,
+        "progressItemsCount": 5,
+        "filesSummaryFile": 2,
+        "outputContent": 0,
+        "storageType": 1,
+        "storageAccountID": "aeb01bc8-9292-47a7-88a3-8fc89ebc3e10",
+        "isStopped": false,
+        "indexIsDeleted": false,
+        "targetType": null,
+        "targetSmtp": null,
+        "autoStartExport": true,
+        "deleteSearch": false,
+        "dedupItems": false,
+        "exportMetadata": "[{\"MasterIndexField\":\"200b9c27-b497-4977-82e7-1586b32a5871\",\"DisplayName\":\"Record Class\",\"PropertyName\":\"record_class\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"90ee0e13-8639-4c4a-b542-66b6c8911549\",\"DisplayName\":\"Archived Date\",\"PropertyName\":\"ingestionDate\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"a9b8daf2-d9ff-4815-b65a-f6ae2763b92c\",\"DisplayName\":\"Client Identifier\",\"PropertyName\":\"client_identifier\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"109b6bf1-57a0-48ec-b22e-c7248dc74f91\",\"DisplayName\":\"Contributor\",\"PropertyName\":\"contributor\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"893048bf-1e7c-4811-9abf-00cd77a715cf\",\"DisplayName\":\"Record Date\",\"PropertyName\":\"recordDate\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"fdd0fcbb-da46-4af1-a627-ac255c12bb23\",\"DisplayName\":\"ObjectId\",\"PropertyName\":\"bf_012\",\"PropertyType\":\"number\",\"IsMasked\":false},{\"MasterIndexField\":\"1332b6b2-d4b1-4a9a-b13d-f5a08d9cc803\",\"DisplayName\":\"ParentId\",\"PropertyName\":\"bf_013\",\"PropertyType\":\"number\",\"IsMasked\":false},{\"MasterIndexField\":\"0eb3adc8-f220-4074-9ad4-64c43313b5c6\",\"DisplayName\":\"Channel\",\"PropertyName\":\"bf_014\",\"PropertyType\":\"number\",\"IsMasked\":false},{\"MasterIndexField\":\"9af92904-442c-44c1-916c-c1ee6d019140\",\"DisplayName\":\"MaxChannels\",\"PropertyName\":\"bf_015\",\"PropertyType\":\"number\",\"IsMasked\":false},{\"MasterIndexField\":\"03d413d8-126e-4330-ba76-ff09405c2856\",\"DisplayName\":\"ObjectType\",\"PropertyName\":\"bf_001\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"2fdfffce-0390-44b0-9b3f-038b790f26ad\",\"DisplayName\":\"CaseNumbers\",\"PropertyName\":\"bf_002\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"6afc68a3-ea09-478c-ad28-a57b846c4d57\",\"DisplayName\":\"FileType\",\"PropertyName\":\"bf_003\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"5aa6b522-bcee-44d3-95d2-5497a636f387\",\"DisplayName\":\"Checksum\",\"PropertyName\":\"bf_005\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"b885df16-7ce4-404c-a0c6-036d071d6a2f\",\"DisplayName\":\"TranscriptRequest\",\"PropertyName\":\"bf_006\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"7cbc7937-87e6-4f8e-bc7b-de552ca8ed1e\",\"DisplayName\":\"TranscriptType\",\"PropertyName\":\"bf_007\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"ad3b574b-f0c7-492e-8a47-c9645b558c09\",\"DisplayName\":\"TranscriptUrgency\",\"PropertyName\":\"bf_008\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"1337a236-c482-4a7d-baa3-4875cb484767\",\"DisplayName\":\"Comments\",\"PropertyName\":\"bf_009\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"ea88ea00-fb7c-41a3-b0c8-adf2bfb8df18\",\"DisplayName\":\"UploadedBy\",\"PropertyName\":\"bf_016\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"5865d506-87d9-4733-8efc-026d636793d4\",\"DisplayName\":\"HearingDate\",\"PropertyName\":\"bf_004\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"519d88cb-dad2-4c6a-ac3a-b41bc3519c68\",\"DisplayName\":\"CreatedDateTime\",\"PropertyName\":\"bf_010\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"0c5b03b8-86f0-45df-a6ab-17085131b54c\",\"DisplayName\":\"StartDateTime\",\"PropertyName\":\"bf_011\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"9fb67f04-5fac-4d41-97ef-ac92267ff0e7\",\"DisplayName\":\"EndDateTime\",\"PropertyName\":\"bf_017\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"94aadf8a-a13e-4b35-af25-034f01f1f2c2\",\"DisplayName\":\"PlaceholderDate\",\"PropertyName\":\"bf_018\",\"PropertyType\":\"date\",\"IsMasked\":false},{\"MasterIndexField\":\"11dc6223-fd52-4714-950b-d74d721f1dae\",\"DisplayName\":\"Courthouse\",\"PropertyName\":\"bf_019\",\"PropertyType\":\"string\",\"IsMasked\":false},{\"MasterIndexField\":\"ae888318-1500-44f4-92b9-f09824e6ae1f\",\"DisplayName\":\"Courtroom\",\"PropertyName\":\"bf_020\",\"PropertyType\":\"string\",\"IsMasked\":false}]",
+        "exportLocation": null,
+        "totalSize": null
+      },
+      "productionExportFile": [
+        {
+          "productionExportFile": {
+            "productionExportFileID": "741d78c1-d722-419d-b72c-74f9972ff60e",
+            "productionID": "1b6a29d9-a72e-420b-8d69-b8acbeed806a",
+            "exportTypeID": 32,
+            "exportFileTypeID": 6,
+            "status": 4,
+            "isBlobLink": false,
+            "streamID": 0,
+            "blobID": null,
+            "blobSize": 2332,
+            "attachmentBlobSize": 0,
+            "nrItemsInOutput": 5,
+            "nrPages": 1,
+            "nrItems": 5,
+            "itemsTotalSize": 0,
+            "nrLists": 1,
+            "creationDT": "2024-08-13T16:50:18.5342135+00:00",
+            "startDT": "2024-08-13T16:50:20.9717025+00:00",
+            "heartbeatDT": "2024-08-13T16:50:20.9717025+00:00",
+            "endDT": "2024-08-13T16:50:21.1748325+00:00",
+            "affinityCookie": null,
+            "errorDescr": null,
+            "fileOrder": 1
+          },
+          "exportFileType": {
+            "exportFileTypeID": 6,
+            "fileType": "CSV V1",
+            "exportFileTypeMime": "text/CSV",
+            "exportFileTypeFolder": "PST",
+            "exportFileTypeExtension": ".csv"
+          },
+          "exportType": {
+            "exportTypeID": 32,
+            "name": "SearchTable"
+          }
+        }
+      ],
+      "rights": null,
+      "itemsCount": 1,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3803)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=190)


### Change description ###
# Summary of Git Diff

A new JSON mapping file for the API endpoint `/api/v1/getProductionOutputFiles` has been created. This file defines the request structure and the response structure, which includes detailed information about production output files.

## Highlights

- **Request Configuration**:
  - **Method**: POST
  - **Headers**: Content-Type must contain `application/json`
  - **URL Path**: `/api/v1/getProductionOutputFiles`
  - **Body Pattern**: Must match `{"productionId":"1b6a29d9-a72e-420b-8d69-b8acbeed806a"}`

- **Response Structure**:
  - **Status**: 200 OK
  - **Headers**: Content-Type is `application/json`
  - **Response Body**:
    - **Production Details**:
      - `productionID`: "1b6a29d9-a72e-420b-8d69-b8acbeed806a"
      - `name`: "DARTS_RPO_2024-08-13_CSV"
      - `itemsCount`: 5
      - `status`: 4
      - `lastUpdateTime`: "2024-08-13T16:50:21.1505806+00:00"
      - **Export Metadata**: Includes various fields such as `MasterIndexField`, `DisplayName`, `PropertyName`, and `PropertyType`.

- **Export File Details**:
  - **Export File Type**: CSV V1
  - **Export File Type ID**: 6
  - **Export Type**: "SearchTable"
  - **Creation Time**: "2024-08-13T16:50:18.5342135+00:00"

This new mapping file enhances the API's capability to handle requests and provide structured responses related to production output files.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
