### PR TITLE
DMP-3843: ARM RPO - Stub for new ARM endpoint - getExtendedSearchesByMatter

### DIFF
--- a/wiremock/mappings/arm/v1_getExtendedSearchesByMatter.json
+++ b/wiremock/mappings/arm/v1_getExtendedSearchesByMatter.json
@@ -1,0 +1,74 @@
+{
+  "request": {
+    "method": "POST",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPath": "/api/v1/getExtendedSearchesByMatter",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"filter\":\"1\",\"filterBy\":{},\"matterId\":\"cb70c7fa-8972-4400-af1d-ff5dd76d2104\",\"usePaging\":true,\"rowsNumber\":10,\"pageIndex\":0,\"orderBy\":\"createdDate\",\"orderByAsc\":false,\"search\":\"\"}"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "searches": [
+        {
+          "search": {
+            "searchID": "8271f101-8c14-4c41-8865-edc5d8baed99",
+            "matterID": "cb70c7fa-8972-4400-af1d-ff5dd76d2104",
+            "indexID": "c19454c6-c378-43c1-ae59-d0d013e30915",
+            "name": "DARTS_RPO_2024-08-13",
+            "description": "",
+            "createdDate": "2024-08-13T16:40:38.3681103+00:00",
+            "totalCount": 5,
+            "userID": "3cda3b0c-7b80-4c5e-b374-5015a90191ac",
+            "lock": false,
+            "etlType": null,
+            "timezone": "Europe/London",
+            "clientTimezone": "Europe/London",
+            "continuationToken": null,
+            "materializedItemsCount": 5,
+            "maxMaterializedItemsCount": 100,
+            "status": 1,
+            "isSaved": true,
+            "isPaused": false,
+            "isDeleted": false,
+            "isReset": false,
+            "isForO365": false,
+            "createExport": false,
+            "isError": false,
+            "errorText": null,
+            "priority": 0,
+            "heartBeat": "2024-08-13T16:43:17.218383+00:00",
+            "searchAfter": "[1723556884128,\"4b955aac-9dec-7a7e-ac20-01914bfc32e8\"]",
+            "sortingField": "ingestionDate",
+            "sortingType": 1,
+            "isCreateExportError": false,
+            "hasDeletedItems": false,
+            "initialMaterializedItemsCount": 0
+          },
+          "exportsCount": 1,
+          "username": "Id: 7812",
+          "ttl": null,
+          "expirationDate": null
+        }
+      ],
+      "itemsCount": 1,
+      "status": 200,
+      "demoMode": false,
+      "isError": false,
+      "responseStatus": 0,
+      "responseStatusMessages": null,
+      "exception": null,
+      "message": null
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3843)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=191)


### Change description ###
# Summary of Git Diff

A new JSON file has been added to the WireMock mappings directory, defining a mock API endpoint for retrieving extended searches by matter. This file specifies the request structure and the expected response for the `/api/v1/getExtendedSearchesByMatter` endpoint.

## Highlights

- **New File**: `v1_getExtendedSearchesByMatter.json` created.
  
- **Request Details**:
  - **Method**: POST
  - **URL Path**: `/api/v1/getExtendedSearchesByMatter`
  - **Content-Type**: Must contain `application/json`
  - **Request Body**: Includes filters and pagination details.
  
- **Response Structure**:
  - **Status**: 200 (OK)
  - **Response Content-Type**: `application/json`
  - **Response Body**:
    - Contains an array of searches, each with detailed attributes such as `searchID`, `matterID`, `createdDate`, and various flags regarding the state of the search.
    - Additional fields include `itemsCount` and `status` indicating the overall result of the operation.
  
- **Example Data**: The response includes a sample search object with attributes such as `name`, `totalCount`, and `errorText`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
