### PR TITLE
DMP-3804: ARM RPO - Stub for new ARM endpoint - downloadProduction

### DIFF
--- a/wiremock/__files/downloadProduction/CSV.csv
+++ b/wiremock/__files/downloadProduction/CSV.csv
@@ -1,0 +1,1 @@
+﻿Record Class,Archived Date,Client Identifier,Contributor,Record Date,ObjectId,ParentId,Channel,MaxChannels,ObjectType,CaseNumbers,FileType,Checksum,TranscriptRequest,TranscriptType,TranscriptUrgency,Comments,UploadedBy,HearingDate,CreatedDateTime,StartDateTime,EndDateTime,Courthouse,Courtroom

--- a/wiremock/mappings/arm/v1_downloadProduction.json
+++ b/wiremock/mappings/arm/v1_downloadProduction.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "urlPathPattern": "/api/v1/downloadProduction/([A-Za-z\\-]+)/false"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "downloadProduction/CSV.csv",
+    "headers": {
+      "Content-Type": "application/csv"
+    }
+  }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3804)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.reform%3Adarts-stub-services&pullRequest=192)


### Change description ###
# Git Diff Summary

This Git diff introduces two new files related to the download production functionality. It adds a CSV file that outlines the structure of records and a JSON mapping file for handling GET requests.

## Highlights
- **New CSV File**: 
  - Path: `wiremock/__files/downloadProduction/CSV.csv`
  - Contains headers for record-related data including fields like `Record Class`, `Archived Date`, `Client Identifier`, etc.

- **New JSON Mapping File**:
  - Path: `wiremock/mappings/arm/v1_downloadProduction.json`
  - Defines a GET request handler for the URL path `/api/v1/downloadProduction/([A-Za-z\\-]+)/false`.
  - Sets the response status to 200 and specifies that the response body should use the newly created CSV file, with a content type of `application/csv`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
